### PR TITLE
Fix results directory creation when running for the first time

### DIFF
--- a/run.py
+++ b/run.py
@@ -9,7 +9,7 @@ RESULTS_DIR = Path("results", time.strftime('%Y%m%d-%H%M%S'))
 
 # create results directory if it does not exist
 if not RESULTS_DIR.exists():
-    RESULTS_DIR.mkdir()
+    RESULTS_DIR.mkdir(parents=True)
 
 # Settings to run a negotiation session:
 #   You need to specify the classpath of 2 agents to start a negotiation. Parameters for the agent can be added as a dict (see example)

--- a/run_tournament.py
+++ b/run_tournament.py
@@ -9,7 +9,7 @@ RESULTS_DIR = Path("results", time.strftime('%Y%m%d-%H%M%S'))
 
 # create results directory if it does not exist
 if not RESULTS_DIR.exists():
-    RESULTS_DIR.mkdir()
+    RESULTS_DIR.mkdir(parents=True)
 
 # Settings to run a negotiation session:
 #   You need to specify the classpath of 2 agents to start a negotiation. Parameters for the agent can be added as a dict (see example)


### PR DESCRIPTION
Fixes the following error:
```bash
$ python run.py
Traceback (most recent call last):
  File "E:\Dev\Downloaded\ANL-2022-example-agent\run.py", line 12, in <module>
    RESULTS_DIR.mkdir()
  File "C:\Program Files\Python39\lib\pathlib.py", line 1323, in mkdir
    self._accessor.mkdir(self, mode)
FileNotFoundError: [WinError 3] The system cannot find the path specified: 'results\\20220414-135015'
```